### PR TITLE
added --exclude-pr option to filter PRs by title

### DIFF
--- a/src/changelog/mod.rs
+++ b/src/changelog/mod.rs
@@ -49,7 +49,7 @@ struct PullRequest {
   commits: Vec<Commit>,
 }
 
-pub fn get_changelog(verbose: bool, start_revision: &str, end_revision: &str, milestone: &str, repository: &str, dir: &str) -> Result<String> {
+pub fn get_changelog(verbose: bool, start_revision: &str, end_revision: &str, milestone: &str, repository: &str, dir: &str, exclude_pr: &[String]) -> Result<String> {
   if verbose {
     println!("\nCOMMANDS");
     println!("{SEPARATOR_LINE}");
@@ -99,6 +99,10 @@ pub fn get_changelog(verbose: bool, start_revision: &str, end_revision: &str, mi
   // Move all pull requests to sorted map.
   let mut pull_request_map = BTreeMap::new();
   for pull_request in &pull_requests {
+    // Skip pull requests that match any exclusion pattern.
+    if exclude_pr.iter().any(|pattern| pull_request.title.contains(pattern)) {
+      continue;
+    }
     // From commit map remove commits that are included in pull request.
     for commit in &pull_request.commits {
       commit_map.remove(&commit.hash);


### PR DESCRIPTION
### What
Adds a new repeatable `--exclude-pr <string>` option to the `changelog` subcommand.

When provided, pull requests whose titles contain any of the specified strings
are excluded from the generated changelog.

Example:
magg changelog ... --exclude-pr "Release" --exclude-pr "Bump"

---

### Why
Some repositories contain automated or release-related PRs that should not
appear in human-readable changelogs.

This feature allows maintainers to easily filter out such PRs, as requested in #2.

---

### How
- Added a repeatable CLI flag to the `changelog` subcommand
- Wired the flag through the Action enum and call chain
- Filtered PRs before insertion into `pull_request_map` (per maintainer hint)
- Preserved existing behavior when the flag is not used

---

### Notes
- No existing behavior is changed unless `--exclude-pr` is provided
- Filtering is based on simple substring matching, as requested
- Commits from excluded PRs remain listed as standalone commits

Closes #2